### PR TITLE
feat: upgrade AWS provider to latest 6.x.x version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this module will be documented in this file.
 
+## [1.2.0] - 2025-06-11
+
+### Updated
+
+- Upgraded AWS provider from `>= 4.0` to `~> 6.0` to use the latest 6.x.x version
+- Updated all example configurations to use AWS provider `~> 6.0`
+- Updated documentation to reflect new provider requirements
+
 ## [1.1.1] - 2025-06-11
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ module "ses" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 

--- a/examples/domain-verification/versions.tf
+++ b/examples/domain-verification/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = "~> 6.0"
     }
   }
 

--- a/examples/email-verification/versions.tf
+++ b/examples/email-verification/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = "~> 6.0"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
Closes #7

Upgraded the AWS provider from `>= 4.0` to `~> 6.0` to use the latest 6.x.x version.

## Changes:
- Updated AWS provider version constraint in main module
- Updated all example configurations
- Updated README.md documentation
- Added CHANGELOG.md entry for v1.2.0

All SES, Route53, and IAM resources remain compatible with AWS provider 6.x.

Generated with [Claude Code](https://claude.ai/code)